### PR TITLE
Improve PicassoPredictors

### DIFF
--- a/picasso/predictors.py
+++ b/picasso/predictors.py
@@ -78,7 +78,7 @@ def _gas_par2gas_props(gas_par, phi_tot, r_R500):
     rho_g, P_tot = polytrop.rho_P_g(phi_tot, *gas_par[:4])
     f_nth = nonthermal.f_nt_nelson14(r_R500, *gas_par[4:])
     P_th = P_tot * (1 - f_nth)
-    return jnp.array([rho_g, P_th, f_nth])
+    return jnp.array([rho_g, P_tot, P_th, f_nth])
 
 
 _gas_par2gas_props_v = jax.vmap(_gas_par2gas_props, out_axes=1)
@@ -160,6 +160,8 @@ class PicassoPredictor:
 
             - rho_g : Array
                 The predicted gas density.
+            - P_tot : Array
+                The predicted total pressure.
             - P_th : Array
                 The predicted thermal pressure.
             - f_nth : Array
@@ -167,10 +169,14 @@ class PicassoPredictor:
         """
         gas_par = self.predict_model_parameters(x, net_par)
         if len(gas_par.shape) == 1:
-            rho_g, P_th, f_nth = _gas_par2gas_props(gas_par, phi, r_R500)
+            rho_g, P_tot, P_th, f_nth = _gas_par2gas_props(
+                gas_par, phi, r_R500
+            )
         else:
-            rho_g, P_th, f_nth = _gas_par2gas_props_v(gas_par, phi, r_R500)
-        return (rho_g, P_th, f_nth)
+            rho_g, P_tot, P_th, f_nth = _gas_par2gas_props_v(
+                gas_par, phi, r_R500
+            )
+        return (rho_g, P_tot, P_th, f_nth)
 
 
 class PicassoTrainedPredictor(PicassoPredictor):
@@ -186,11 +192,11 @@ class PicassoTrainedPredictor(PicassoPredictor):
         self.net_par = net_par
 
     def predict_gas_model(
-        self, x: Array, phi: Array, r_R500: Array
+        self, x: Array, phi: Array, r_R500: Array, *args
     ) -> Sequence[Array]:
         return super().predict_gas_model(x, phi, r_R500, self.net_par)
 
-    def predict_model_parameters(self, x: Array) -> Array:
+    def predict_model_parameters(self, x: Array, *args) -> Array:
         return super().predict_model_parameters(x, self.net_par)
 
 

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -76,7 +76,7 @@ def test_picasso_predictor():
     phi = jnp.ones((n_halos, n_pts))
     r_R500 = jnp.ones((n_halos, n_pts))
     gas_model = predictor.predict_gas_model(x, phi, r_R500)
-    assert len(gas_model) == 3
+    assert len(gas_model) == 4
     assert gas_model[0].shape == (n_halos, n_pts)
     assert gas_model[1].shape == (n_halos, n_pts)
     assert gas_model[2].shape == (n_halos, n_pts)
@@ -116,7 +116,7 @@ def test_predict_gas_properties_pretrained(jit, benchmark):
     )
     profs_pred = jnp.array(profs_pred)
     assert profs_pred.shape == (
-        3,
+        4,
         data_predictor["x"].shape[0],
         data_predictor["phi"].shape[1],
     )


### PR DESCRIPTION
Make `PicassoPredictor` classes easier to use in training loops:
* Splits `PicassoPredictor` in `PicassoPredictor` and `PicassoTrainedPredictor`, the former requiring a set of network parameters to make any predictions (thus useful for training loops), and the latter only requiring it at instanciation
* Add options to fix some of the model parameters (i.e. fix network parameter outputs)